### PR TITLE
Ajuste na serialização de relacionamento e uso de Enum para tipo de conta PL-04

### DIFF
--- a/new_release.md
+++ b/new_release.md
@@ -6,4 +6,5 @@
 * Finish for another view (PL-01)
 * Adicionada criação de usuário e conta com vínculo dinâmico, e pesquisar usuários por nome e ID. (PL-02)
 * Adicionada validação para criação de conta, evitando saldo negativo e duplicação de usuários, com suporte para telefone e e-mail opcionais. (PL-03)
+* Adicionada validação para o tipo de conta com enum AccountType. (PL-04)
 

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,12 @@
 			<artifactId>jakarta.el</artifactId>
 			<version>3.0.4</version>
 		</dependency>
+		<dependency>
+			<groupId>org.jetbrains</groupId>
+			<artifactId>annotations</artifactId>
+			<version>17.0.0</version>
+			<scope>compile</scope>
+		</dependency>
 
 	</dependencies>
 

--- a/src/main/java/bank/consult/springboot/controller/AccountController.java
+++ b/src/main/java/bank/consult/springboot/controller/AccountController.java
@@ -36,7 +36,7 @@ public class AccountController {
         return user;
     }
 
-    // Método POST para criar uma conta com os parâmetros necessários
+    // cria uma conta com os parâmetros necessários
     @PostMapping
     public AccountDTO createAccount(@RequestParam @NotNull String firstName,
                                     @RequestParam @NotNull String lastName,

--- a/src/main/java/bank/consult/springboot/controller/AccountController.java
+++ b/src/main/java/bank/consult/springboot/controller/AccountController.java
@@ -3,6 +3,7 @@ package bank.consult.springboot.controller;
 
 import bank.consult.springboot.dto.AccountDTO;
 import bank.consult.springboot.entity.UserEntity;
+import bank.consult.springboot.enums.AccountType;
 import bank.consult.springboot.service.AccountService;
 import jakarta.validation.constraints.NotNull;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -39,12 +40,15 @@ public class AccountController {
     @PostMapping
     public AccountDTO createAccount(@RequestParam @NotNull String firstName,
                                     @RequestParam @NotNull String lastName,
-                                    @RequestParam @NotNull String accountType,
+                                    @RequestParam @NotNull String accountType,  // Aqui vai vir como String
                                     @RequestParam @NotNull double initialBalance,
-                                    @RequestParam(required = false) String phone,  // Parâmetro opcional
-                                    @RequestParam(required = false) String email) {  // Parâmetro opcional
+                                    @RequestParam(required = false) String phone,
+                                    @RequestParam(required = false) String email) {
         try {
-            return accountService.createAccount(firstName, lastName, accountType, initialBalance, phone, email);
+            // Converte a string para o enum AccountType o tipo da conta
+            AccountType type = AccountType.valueOf(accountType.toUpperCase());
+
+            return accountService.createAccount(firstName, lastName, type, initialBalance, phone, email);
         } catch (IllegalArgumentException e) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage());
         }

--- a/src/main/java/bank/consult/springboot/dto/AccountDTO.java
+++ b/src/main/java/bank/consult/springboot/dto/AccountDTO.java
@@ -14,18 +14,13 @@ public class AccountDTO {
 
     @NotNull
     private Long id;
-
     @NotNull
     private Long userId;
-
     @NotNull
     private String accountType;
-
     @NotNull
     private BigDecimal balance;
-
     @NotNull
     private LocalDateTime createdAt;
-
     private String successMessage;  // Mensagem de sucesso quando a conta for criada
 }

--- a/src/main/java/bank/consult/springboot/dto/UserDTO.java
+++ b/src/main/java/bank/consult/springboot/dto/UserDTO.java
@@ -1,6 +1,7 @@
 package bank.consult.springboot.dto;
 
 
+import org.jetbrains.annotations.Nullable;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -15,7 +16,9 @@ public class UserDTO {
     private String firstName;
     @NotNull
     private String lastName;
+    @Nullable
     private String email;
+    @Nullable
     private String phone;
     private List<AccountDTO> accounts;
 }

--- a/src/main/java/bank/consult/springboot/entity/AccountEntity.java
+++ b/src/main/java/bank/consult/springboot/entity/AccountEntity.java
@@ -1,6 +1,7 @@
 package bank.consult.springboot.entity;
 
 import bank.consult.springboot.enums.AccountType;
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -20,12 +21,13 @@ public class AccountEntity {
     private Long id;
 
     @ManyToOne
-    @JoinColumn(name = "user_id", nullable = false)  // Relaciona com a tabela 'users' através da coluna 'user_id'
-    private UserEntity user;  // Associa a conta ao usuário
+    @JoinColumn(name = "user_id", nullable = false)
+    @JsonBackReference  // Evita a serialização do usuário dentro da conta
+    private UserEntity user;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "account_type")
-    private AccountType accountType;  // Alterado para AccountType
+    private AccountType accountType;
 
     @Column(name = "balance")
     private BigDecimal balance;
@@ -33,8 +35,7 @@ public class AccountEntity {
     @Column(name = "created_at")
     private LocalDateTime createdAt;
 
-    // Construtor atualizado para aceitar AccountType
-    public AccountEntity(UserEntity user, AccountType accountType, BigDecimal balance) {  // Alterado para AccountType
+    public AccountEntity(UserEntity user, AccountType accountType, BigDecimal balance) {
         this.user = user;
         this.accountType = accountType;
         this.balance = balance;

--- a/src/main/java/bank/consult/springboot/entity/AccountEntity.java
+++ b/src/main/java/bank/consult/springboot/entity/AccountEntity.java
@@ -1,5 +1,6 @@
 package bank.consult.springboot.entity;
 
+import bank.consult.springboot.enums.AccountType;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -22,9 +23,9 @@ public class AccountEntity {
     @JoinColumn(name = "user_id", nullable = false)  // Relaciona com a tabela 'users' através da coluna 'user_id'
     private UserEntity user;  // Associa a conta ao usuário
 
-
+    @Enumerated(EnumType.STRING)
     @Column(name = "account_type")
-    private String accountType;
+    private AccountType accountType;  // Alterado para AccountType
 
     @Column(name = "balance")
     private BigDecimal balance;
@@ -32,7 +33,8 @@ public class AccountEntity {
     @Column(name = "created_at")
     private LocalDateTime createdAt;
 
-    public AccountEntity(UserEntity user, String accountType, BigDecimal balance) {
+    // Construtor atualizado para aceitar AccountType
+    public AccountEntity(UserEntity user, AccountType accountType, BigDecimal balance) {  // Alterado para AccountType
         this.user = user;
         this.accountType = accountType;
         this.balance = balance;

--- a/src/main/java/bank/consult/springboot/entity/UserEntity.java
+++ b/src/main/java/bank/consult/springboot/entity/UserEntity.java
@@ -1,6 +1,7 @@
 package bank.consult.springboot.entity;
 
 
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -34,6 +35,7 @@ public class UserEntity {
     @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt= LocalDateTime.now();
 
+    @JsonManagedReference
     @OneToMany(mappedBy = "user")
     private List<AccountEntity> accounts;
 }

--- a/src/main/java/bank/consult/springboot/entity/UserEntity.java
+++ b/src/main/java/bank/consult/springboot/entity/UserEntity.java
@@ -25,19 +25,19 @@ public class UserEntity {
     @Column(name = "first_name")
     private String firstName;
 
-    @Column (name = "last_name")
+    @Column(name = "last_name")
     private String lastName;
-
 
     private String email;
     private String phone;
 
     @Column(name = "created_at", updatable = false)
-    private LocalDateTime createdAt= LocalDateTime.now();
+    private LocalDateTime createdAt = LocalDateTime.now();
 
-    @JsonManagedReference
     @OneToMany(mappedBy = "user")
+    @JsonManagedReference  // Controla a serialização das contas associadas ao usuário
     private List<AccountEntity> accounts;
 }
+
 
 

--- a/src/main/java/bank/consult/springboot/enums/AccountType.java
+++ b/src/main/java/bank/consult/springboot/enums/AccountType.java
@@ -1,0 +1,6 @@
+package bank.consult.springboot.enums;
+
+public enum AccountType {
+    CORRENTE,
+    POUPANCA
+}

--- a/src/main/java/bank/consult/springboot/repository/UserRepository.java
+++ b/src/main/java/bank/consult/springboot/repository/UserRepository.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 public interface UserRepository extends JpaRepository<UserEntity, Long> {
 
-    // Metodo para buscar usuario pelo primeiro nome e sobrenome
+    // Metodo para verificar se user ja existe e dps criar uma conta
     @Query("SELECT u FROM UserEntity u WHERE LOWER(u.firstName) = LOWER(:firstName) AND LOWER(u.lastName) = LOWER(:lastName)")
     List<UserEntity> findByFirstNameAndLastName(String firstName, String lastName);
 

--- a/src/main/java/bank/consult/springboot/service/AccountService.java
+++ b/src/main/java/bank/consult/springboot/service/AccountService.java
@@ -3,6 +3,7 @@ package bank.consult.springboot.service;
 import bank.consult.springboot.dto.AccountDTO;
 import bank.consult.springboot.entity.AccountEntity;
 import bank.consult.springboot.entity.UserEntity;
+import bank.consult.springboot.enums.AccountType;
 import bank.consult.springboot.repository.AccountRepository;
 import bank.consult.springboot.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,35 +26,48 @@ public class AccountService {
         return !existingUser.isEmpty();
     }
 
-    // Aqui cria uma conta e um usuário
-    public AccountDTO createAccount(String firstName, String lastName, String accountType, double initialBalance, String phone, String email) {
-
-        // Verifica se o usuário já existe
+    // Criação de uma conta e um usuário
+    public AccountDTO createAccount(String firstName, String lastName, AccountType accountType, double initialBalance, String phone, String email) {
         if (userExists(firstName, lastName)) {
             throw new IllegalArgumentException("Já existe um usuário com esse nome.");
         }
+        if (initialBalance < 0) {
+            throw new IllegalArgumentException("Saldo inicial não pode ser negativo.");
+        }
+
+        // Criação do usuário
         UserEntity userEntity = new UserEntity();
         userEntity.setFirstName(firstName);
         userEntity.setLastName(lastName);
-        userEntity.setPhone(phone != null ? phone : "0000000000");  // Se o telefone não for passado, o valor padrão será "0000000000"
-        userEntity.setEmail(email != null ? email : "default@domain.com");  // Se o email não for passado, o valor padrão será "default@domain.com"
+        userEntity.setEmail(email != null ? email : "defaultEmail@example.com");  // Default email se não enviado
+        userEntity.setPhone(phone != null ? phone : "0000000000");  // Default phone se não enviado
+
+        // Salvando o usuário no banco
         UserEntity savedUser = userRepository.save(userEntity);
-        // Criação da conta para o usuário
+
+        // Criando a conta com o tipo de conta baseado no enum
         AccountEntity accountEntity = new AccountEntity(
-                savedUser,  // Associando o usuário à conta
-                accountType,  // Tipo da conta (corrente, poupança, etc.)
-                BigDecimal.valueOf(initialBalance)  // Saldo inicial
+                savedUser,
+                accountType,  // Usando o tipo do enum
+                BigDecimal.valueOf(initialBalance)
         );
+
+        // Salvando a conta no banco
         AccountEntity savedAccount = accountRepository.save(accountEntity);
+
+        // Retornando a DTO da conta
         return new AccountDTO(
                 savedAccount.getId(),
                 savedAccount.getUser().getId(),
-                savedAccount.getAccountType(),
+                savedAccount.getAccountType().name(),  // Convertendo enum para string
                 savedAccount.getBalance(),
                 savedAccount.getCreatedAt(),
-                "Conta criada com sucesso para " + savedUser.getFirstName() + " " + savedUser.getLastName() + " com o tipo de conta: " + accountType
+                "Conta criada com sucesso para " + savedAccount.getUser().getFirstName() + " com tipo de conta: " + savedAccount.getAccountType().name()
         );
     }
+
+
+
 
     // Aqui busca usuario pelo nome, sobrenome e ID com camel sensitive
     public UserEntity getUserByNameAndLastNameAndId(String firstName, String lastName, Long id) {

--- a/src/main/java/bank/consult/springboot/service/AccountService.java
+++ b/src/main/java/bank/consult/springboot/service/AccountService.java
@@ -39,23 +39,16 @@ public class AccountService {
         UserEntity userEntity = new UserEntity();
         userEntity.setFirstName(firstName);
         userEntity.setLastName(lastName);
-        userEntity.setEmail(email != null ? email : "defaultEmail@example.com");  // Default email se não enviado
-        userEntity.setPhone(phone != null ? phone : "0000000000");  // Default phone se não enviado
-
-        // Salvando o usuário no banco
+        userEntity.setEmail(email != null ? email : "defaultEmail@example.com");
+        userEntity.setPhone(phone != null ? phone : "0000000000");
         UserEntity savedUser = userRepository.save(userEntity);
-
         // Criando a conta com o tipo de conta baseado no enum
         AccountEntity accountEntity = new AccountEntity(
                 savedUser,
                 accountType,  // Usando o tipo do enum
                 BigDecimal.valueOf(initialBalance)
         );
-
-        // Salvando a conta no banco
         AccountEntity savedAccount = accountRepository.save(accountEntity);
-
-        // Retornando a DTO da conta
         return new AccountDTO(
                 savedAccount.getId(),
                 savedAccount.getUser().getId(),
@@ -65,9 +58,6 @@ public class AccountService {
                 "Conta criada com sucesso para " + savedAccount.getUser().getFirstName() + " com tipo de conta: " + savedAccount.getAccountType().name()
         );
     }
-
-
-
 
     // Aqui busca usuario pelo nome, sobrenome e ID com camel sensitive
     public UserEntity getUserByNameAndLastNameAndId(String firstName, String lastName, Long id) {


### PR DESCRIPTION
Fix na serialização de relacionamento entre **`UserEntity`** e **`AccountEntity`**, resolvendo o problema de loop infinito no JSON ao usar **`@JsonBackReference`** e `@JsonManagedReference`.

Adição de um **`Enum`** para o tipo de conta (**CURRENTE**, **POUPANCA**), garantindo que apenas valores válidos sejam armazenados no banco de dados.

Agora, o retorno de dados na API está correto, sem duplicações ou referência circular entre as entidades.