### PR TITLE
Ajuste no Docker e criação do script para povoar o banco PL-07

### DIFF
--- a/NEW_RELEASE.md
+++ b/NEW_RELEASE.md
@@ -12,3 +12,4 @@
 * Mensagem personalizada ao sacar: Ao realizar um saque, uma mensagem é retornada com o valor final da conta do usuário. (PL-05)
 * Consulta de saldo: Adicionada a funcionalidade de verificação de saldo, retornando uma mensagem clara com o valor da conta. (PL-05)
 * Adicionar testes unitários para AccountService cobrindo criação de conta, depósito, saque e consulta de saldo. (PL-06)
+* Ajuste no Docker e criação do script para povoar o banco. (PL-07)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3.1'
+
+services:
+  postgresdb:
+    image: postgres:latest
+    container_name: postgresbank
+    environment:
+      POSTGRES_USER: bankduell
+      POSTGRES_PASSWORD: bankduell
+      POSTGRES_DB: postgresbank
+    ports:
+      - "5432:5432"
+    volumes:
+      - ./src/main/resources/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d  # script SQL de insert

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,7 +5,7 @@ spring.datasource.username=bankduell
 spring.datasource.password=bankduell
 spring.datasource.driver-class-name
 
-spring.jpa.hibernate.ddl-auto
+spring.jpa.hibernate.ddl-none
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=
 

--- a/src/main/resources/docker-entrypoint-initdb.d/populate_db.sql
+++ b/src/main/resources/docker-entrypoint-initdb.d/populate_db.sql
@@ -1,0 +1,6 @@
+INSERT INTO users (first_name, last_name, email, phone)
+VALUES
+('Armando', 'Jose', 'tuco.todes@example.com', '987654321'),
+('Jurandir', 'Ferreira', 'jurandir.ferreira@example.com', '123456789'),
+('Maria', 'Silva', 'maria.silva@example.com', '654321987');
+


### PR DESCRIPTION
Este PR realiza as seguintes mudanças no projeto:
- Adição de um script SQL (`populate_db.sql`) para povoar o banco de dados com dados iniciais (usuários e contas).
- Configuração no `docker-compose.yml` para mapear corretamente o arquivo `populate_db.sql` dentro do contêiner PostgreSQL.
- Ajustes para garantir que o banco de dados seja populado automaticamente quando o contêiner do Docker for iniciado.

Agora, ao iniciar o Docker, o banco de dados será povoado com dados iniciais, facilitando o teste e a execução do projeto.

#### Alterações:
1. **Docker**: Configuração do arquivo `docker-compose.yml` para incluir o script de inicialização.
2. **Banco de Dados**: Inclusão do script `populate_db.sql` para inserir dados no banco de dados após inicialização.
